### PR TITLE
Phase 4: Qdrant ストア実装

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true,
+    "paths": {}
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,13 @@
-/** 使用する埋め込みモデル。768 次元ベクターを生成する */
+// ── 埋め込みモデル ──────────────────────────────────────────────────────────
+
+/** 使用する埋め込みモデル */
 export const EMBED_MODEL = "nomic-ai/nomic-embed-text-v1.5";
 
 /** モデル初期化失敗時の最大リトライ回数 */
 export const EMBED_MAX_RETRIES = 3;
+
+/** nomic-embed-text-v1.5 の出力ベクター次元数 */
+export const VECTOR_SIZE = 768;
 
 /** @huggingface/transformers pipeline で使用するタスク種別 */
 export const PipelineTask = {
@@ -14,3 +19,19 @@ export const PipelineTask = {
 } as const;
 
 export type PipelineTask = (typeof PipelineTask)[keyof typeof PipelineTask];
+
+// ── Qdrant ──────────────────────────────────────────────────────────────────
+
+/** Qdrant サーバーの接続 URL */
+export const QDRANT_URL = "http://localhost:6333";
+
+/** セッションデータを格納する Qdrant コレクション名 */
+export const COLLECTION_NAME = "claude_sessions";
+
+// ── クエリ ──────────────────────────────────────────────────────────────────
+
+/** list_sessions / search_sessions のデフォルト取得件数 */
+export const LIST_DEFAULT_LIMIT = 5;
+
+/** list_sessions / search_sessions の最大取得件数 */
+export const LIST_MAX_LIMIT = 10;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,25 @@
 #!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { initCollection } from "@/store/index.js";
 
+/**
+ * recall MCP サーバーのエントリポイント。
+ *
+ * 起動時に Qdrant コレクションを初期化し、stdio トランスポートで MCP サーバーを起動する。
+ * ログは MCP プロトコルの stdout を汚染しないよう、すべて stderr に出力する。
+ */
 const server = new McpServer({
   name: "recall",
   version: "0.1.0",
 });
 
+await initCollection();
+
+/** Claude Code との通信に stdio を使用する。MCP は stdout を制御チャネルとして使うため、ログは stderr のみ */
 const transport = new StdioServerTransport();
+
+/** トランスポートを接続して MCP サーバーをリクエスト待機状態にする */
 await server.connect(transport);
+
 process.stderr.write("recall MCP server started\n");

--- a/src/store/client.ts
+++ b/src/store/client.ts
@@ -1,0 +1,20 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+import { QDRANT_URL, COLLECTION_NAME, VECTOR_SIZE } from "@/constants.js";
+
+export const qdrant = new QdrantClient({ url: QDRANT_URL });
+
+/** 起動時にコレクションの存在を確認し、なければ自動作成する */
+export async function initCollection(): Promise<void> {
+  try {
+    await qdrant.getCollection(COLLECTION_NAME);
+  } catch {
+    await qdrant.createCollection(COLLECTION_NAME, {
+      vectors: { size: VECTOR_SIZE, distance: "Cosine" },
+    });
+    // order_by: created_at で降順ソートするために datetime インデックスを作成する
+    await qdrant.createPayloadIndex(COLLECTION_NAME, {
+      field_name: "created_at",
+      field_schema: "datetime",
+    });
+  }
+}

--- a/src/store/sessions/index.ts
+++ b/src/store/sessions/index.ts
@@ -1,13 +1,14 @@
-export { initCollection } from "@/store/client.js";
 export {
-  saveSession,
   listSessions,
   searchSessions,
   loadSession,
+} from "@/store/sessions/query.js";
+export {
+  saveSession,
   updateSession,
   deleteSessions,
-} from "@/store/sessions/index.js";
+} from "@/store/sessions/mutation.js";
 export type {
   SaveSessionInput,
   SessionUpdate,
-} from "@/store/sessions/index.js";
+} from "@/store/sessions/mutation.js";

--- a/src/store/sessions/mutation.ts
+++ b/src/store/sessions/mutation.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+import { embed } from "@/embedder/index.js";
+import type { SessionPayload } from "@/models/session.js";
+import { COLLECTION_NAME } from "@/constants.js";
+import { qdrant } from "@/store/client.js";
+import { loadSession } from "@/store/sessions/query.js";
+
+/** title + summary + key_decisions を結合して埋め込みの入力テキストを生成する */
+function buildEmbedInput(
+  payload: Pick<SessionPayload, "title" | "summary" | "key_decisions">,
+): string {
+  return [payload.title, payload.summary, ...payload.key_decisions].join("\n");
+}
+
+export type SaveSessionInput = Omit<
+  SessionPayload,
+  "created_at" | "updated_at"
+>;
+
+/**
+ * 更新可能なフィールドの型。
+ * repos / layer / compacted / created_at / updated_at は更新不可。
+ */
+export type SessionUpdate = Partial<
+  Pick<
+    SessionPayload,
+    | "title"
+    | "summary"
+    | "status"
+    | "key_decisions"
+    | "phase"
+    | "blocked_by"
+    | "code_references"
+    | "external_references"
+    | "github_references"
+    | "artifacts"
+    | "tags"
+  >
+>;
+
+/**
+ * セッションを Qdrant に保存する。
+ *
+ * sourceIds が指定された場合 (compact_sessions 経由) は保存後に元セッションを削除する。
+ */
+export async function saveSession(
+  input: SaveSessionInput,
+  sourceIds?: string[],
+): Promise<{ session_id: string; created_at: string }> {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const vector = await embed(buildEmbedInput(input));
+  const payload: SessionPayload = {
+    ...input,
+    created_at: now,
+    updated_at: now,
+  };
+
+  await qdrant.upsert(COLLECTION_NAME, {
+    points: [{ id, vector, payload: payload as Record<string, unknown> }],
+  });
+
+  if (sourceIds && sourceIds.length > 0) {
+    await deleteSessions(sourceIds);
+  }
+
+  return { session_id: id, created_at: now };
+}
+
+/**
+ * 指定フィールドのみ部分更新する。
+ *
+ * title / summary / key_decisions が含まれる場合はベクターを再生成する。
+ * updated_at は常に自動更新する。
+ */
+export async function updateSession(
+  sessionId: string,
+  updates: SessionUpdate,
+): Promise<{ session_id: string; updated_at: string }> {
+  const current = await loadSession(sessionId);
+  if (!current) {
+    throw new Error(`SESSION_NOT_FOUND: ${sessionId}`);
+  }
+
+  const now = new Date().toISOString();
+  const updatedPayload: SessionPayload = {
+    ...current.payload,
+    ...updates,
+    updated_at: now,
+  };
+
+  const needsReembed =
+    updates.title !== undefined ||
+    updates.summary !== undefined ||
+    updates.key_decisions !== undefined;
+
+  if (needsReembed) {
+    const vector = await embed(buildEmbedInput(updatedPayload));
+    await qdrant.upsert(COLLECTION_NAME, {
+      points: [
+        {
+          id: sessionId,
+          vector,
+          payload: updatedPayload as Record<string, unknown>,
+        },
+      ],
+    });
+  } else {
+    await qdrant.overwritePayload(COLLECTION_NAME, {
+      payload: updatedPayload as Record<string, unknown>,
+      points: [sessionId],
+    });
+  }
+
+  return { session_id: sessionId, updated_at: now };
+}
+
+/** 指定した session_id の配列を一括削除する */
+export async function deleteSessions(
+  sessionIds: string[],
+): Promise<{ deleted: number }> {
+  await qdrant.delete(COLLECTION_NAME, { points: sessionIds });
+  return { deleted: sessionIds.length };
+}

--- a/src/store/sessions/query.ts
+++ b/src/store/sessions/query.ts
@@ -1,0 +1,91 @@
+import type { SessionPayload } from "@/models/session.js";
+import {
+  COLLECTION_NAME,
+  LIST_DEFAULT_LIMIT,
+  LIST_MAX_LIMIT,
+} from "@/constants.js";
+import { embed } from "@/embedder/index.js";
+import { qdrant } from "@/store/client.js";
+
+/** repo / layer フィルターを Qdrant Filter 形式に変換する */
+function buildFilter(repo?: string, layer?: string) {
+  const must: unknown[] = [];
+  if (repo) {
+    must.push({
+      nested: {
+        key: "repos",
+        filter: { must: [{ key: "repo", match: { value: repo } }] },
+      },
+    });
+  }
+  if (layer) {
+    must.push({ key: "layer", match: { value: layer } });
+  }
+  return must.length > 0 ? { must } : undefined;
+}
+
+/** 最近のセッションを created_at 降順で返す */
+export async function listSessions(
+  limit: number = LIST_DEFAULT_LIMIT,
+  repo?: string,
+  layer?: string,
+): Promise<Array<{ id: string; payload: SessionPayload }>> {
+  const clampedLimit = Math.min(limit, LIST_MAX_LIMIT);
+  const filter = buildFilter(repo, layer);
+
+  const result = await qdrant.scroll(COLLECTION_NAME, {
+    filter,
+    limit: clampedLimit,
+    with_payload: true,
+    with_vector: false,
+    order_by: { key: "created_at", direction: "desc" },
+  });
+
+  return result.points.map((p) => ({
+    id: String(p.id),
+    payload: p.payload as unknown as SessionPayload,
+  }));
+}
+
+/** 自然言語クエリでセマンティック検索し、類似度スコア付きで返す */
+export async function searchSessions(
+  query: string,
+  limit: number = LIST_DEFAULT_LIMIT,
+  repo?: string,
+  layer?: string,
+): Promise<Array<{ id: string; score: number; payload: SessionPayload }>> {
+  const clampedLimit = Math.min(limit, LIST_MAX_LIMIT);
+  const vector = await embed(query);
+  const filter = buildFilter(repo, layer);
+
+  const result = await qdrant.search(COLLECTION_NAME, {
+    vector,
+    limit: clampedLimit,
+    filter,
+    with_payload: true,
+  });
+
+  return result.map((p) => ({
+    id: String(p.id),
+    score: p.score,
+    payload: p.payload as unknown as SessionPayload,
+  }));
+}
+
+/** session_id を指定してセッションを1件ロードする。存在しない場合は null を返す */
+export async function loadSession(
+  sessionId: string,
+): Promise<{ id: string; payload: SessionPayload } | null> {
+  const result = await qdrant.retrieve(COLLECTION_NAME, {
+    ids: [sessionId],
+    with_payload: true,
+    with_vector: false,
+  });
+
+  if (result.length === 0) return null;
+  const point = result[0];
+  return {
+    id: String(point.id),
+    payload: point.payload as unknown as SessionPayload,
+  };
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 概要

Issue #4 に対応する。
Qdrant へのセッションデータの保存・取得・検索・更新・削除を担う `src/store/` を実装した。

---

## 実装内容

### 何を、何のために実装したか

**`src/constants.ts` — Qdrant / クエリ関連定数の追加**

`QDRANT_URL` / `COLLECTION_NAME` / `VECTOR_SIZE` / `LIST_DEFAULT_LIMIT` / `LIST_MAX_LIMIT` を追加した。
既存の埋め込みモデル定数と合わせて、グループ別に整理して定義している。

**`src/store/client.ts` — QdrantClient シングルトンとコレクション初期化**

`QdrantClient` をシングルトンとして保持し、起動時に `initCollection()` でコレクションの存在を確認・自動作成する。

> [!IMPORTANT]
>
> `order_by: created_at` で降順ソートするために `createPayloadIndex` で datetime インデックスを作成している。
> このインデックスがないと `listSessions` が Bad Request エラーになる。

**`src/store/sessions/query.ts` — 読み取り系操作**

`listSessions` / `searchSessions` / `loadSession` を実装した。
`repo` / `layer` の2軸フィルターは Qdrant の `nested` フィルター構文で実現している。

**`src/store/sessions/mutation.ts` — 書き込み系操作**

`saveSession` / `updateSession` / `deleteSessions` を実装した。

> [!NOTE]
>
> `updateSession` は `title` / `summary` / `key_decisions` が含まれる場合のみベクターを再生成する。
> それ以外のフィールドのみの変更では `overwritePayload` でペイロードだけ上書きし、埋め込みコストを節約する。

**`src/index.ts` — `initCollection()` の呼び出しを追加**

MCP サーバー起動時にコレクションが自動作成されるよう、エントリポイントに `initCollection()` を追加した。

### この実装がないとどうなるか

Phase 5 / Phase 6 で実装する MCP ツール (`save_session` / `list_sessions` / `search_sessions` など) はすべてこのストア層を経由して Qdrant にアクセスする。
ストア層がないと MCP ツールを実装できない。

### 次の作業 (このPRでやっていないこと)

- Phase 5: MCP ツール実装 基本4本 (`preview_session` / `save_session` / `list_sessions` / `search_sessions`)
- Phase 6: MCP ツール実装 残り4本 (`load_session` / `compact_sessions` / `update_session` / `delete_session`)

---

## 補足事項

`collectionExists()` が期待通りに動作しなかったため、`getCollection()` を try/catch で囲む方式に変更した。

---

## 関連 Issue

close #4

🤖 Generated with Claude Code