### PR TITLE
feat: MCP ツール残り 4 本を実装 (Phase 6)

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -59,22 +59,35 @@ Claude Code を再起動して設定を反映する。
 
 ## 提供ツール一覧
 
-| ツール            | 説明                                           |
-| ----------------- | ---------------------------------------------- |
-| `preview_session` | 保存前にセッション内容をプレビューする         |
-| `save_session`    | セッションを Qdrant に保存する                 |
-| `list_sessions`   | 最近のセッションを降順で一覧表示する           |
-| `load_session`    | 番号または session ID でセッションをロードする |
+| ツール             | 説明                                                  |
+| ------------------ | ----------------------------------------------------- |
+| `preview_session`  | 保存前にセッション内容をプレビューする                |
+| `save_session`     | セッションを Qdrant に保存する                        |
+| `list_sessions`    | 最近のセッションを降順で一覧表示する                  |
+| `load_session`     | 番号または session ID でセッションをロードする        |
+| `search_sessions`  | 自然言語クエリでセマンティック検索する                |
+| `update_session`   | 指定フィールドのみ部分更新する                        |
+| `compact_sessions` | 対象セッションの生データを返す (要約は Claude が行う) |
+| `delete_session`   | session_ids で指定したセッションを一括削除する        |
 
 ## 使用例
 
 ```text
 # プレビューして保存
-今日の作業をプレビューして保存して。タイトル「recall Phase 5」、リポジトリ: tamaco489/recall、layer: backend
+今日の作業をプレビューして保存して。タイトル「recall Phase 6」、リポジトリ: tamaco489/recall、layer: backend
 
 # 一覧表示
 list_sessions で一覧を見せて
 
 # セッションのロード
 1番のセッションをロードして
+
+# セマンティック検索
+「Qdrant ベクターストア実装」に関連するセッションを検索して
+
+# セッション更新
+セッション abc123 のステータスを completed に更新して
+
+# セッション削除
+abc123 と def456 のセッションを削除して
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,22 +59,35 @@ Restart Claude Code to apply the change.
 
 ## Available Tools
 
-| Tool              | Description                            |
-| ----------------- | -------------------------------------- |
-| `preview_session` | Preview session data before saving     |
-| `save_session`    | Save a session to Qdrant               |
-| `list_sessions`   | List recent sessions in reverse order  |
-| `load_session`    | Load a session by number or session ID |
+| Tool               | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `preview_session`  | Preview session data before saving                              |
+| `save_session`     | Save a session to Qdrant                                        |
+| `list_sessions`    | List recent sessions in reverse chronological order             |
+| `load_session`     | Load a session by number or session ID                          |
+| `search_sessions`  | Semantic search using a natural language query                  |
+| `update_session`   | Partially update specified fields                               |
+| `compact_sessions` | Return raw session data for Claude to summarize and consolidate |
+| `delete_session`   | Delete one or more sessions by session ID                       |
 
 ## Usage Example
 
 ```text
 # Preview and save
-Preview and save today's work. Title: "recall Phase 5", repo: tamaco489/recall, layer: backend
+Preview and save today's work. Title: "recall Phase 6", repo: tamaco489/recall, layer: backend
 
 # List sessions
 Show me the list with list_sessions
 
 # Load a session
 Load session number 1
+
+# Search sessions
+Search for sessions related to "Qdrant vector store implementation"
+
+# Update a session
+Update the status of session abc123 to completed
+
+# Delete a session
+Delete sessions with IDs abc123 and def456
 ```

--- a/src/tools/compact_sessions.ts
+++ b/src/tools/compact_sessions.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolName } from "@/constants/index.js";
+import { listSessions, loadSession } from "@/store/index.js";
+
+/**
+ * 対象セッションの生データを返す。
+ * 要約は会話中の Claude が行い、save_session (source_ids 付き) で保存する。
+ */
+export function registerCompactSessions(server: McpServer): void {
+  server.registerTool(
+    ToolName.CompactSessions,
+    {
+      description:
+        "対象セッションの生データを返す。Claude がこの出力を要約し save_session (source_ids 付き) で保存することで、元セッションが自動削除される。",
+      inputSchema: {
+        session_ids: z
+          .array(z.uuid())
+          .optional()
+          .describe(
+            "対象セッション ID を直接指定 (指定した場合は repo / before を無視)",
+          ),
+        repo: z
+          .string()
+          .optional()
+          .describe("repos[].repo での絞り込み (session_ids 未指定時に有効)"),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            "ISO 8601 日時。この日付より古いセッションを対象にする (session_ids 未指定時に有効)",
+          ),
+      },
+    },
+    async ({ session_ids, repo, before }) => {
+      let targets: Array<{ id: string; payload: unknown }>;
+
+      if (session_ids && session_ids.length > 0) {
+        const results = await Promise.all(session_ids.map(loadSession));
+        targets = results
+          .filter((r): r is NonNullable<typeof r> => r !== null)
+          .map((r) => ({ id: r.id, payload: r.payload }));
+      } else {
+        const all = await listSessions(50, repo);
+        targets = before
+          ? all
+              .filter((s) => s.payload.created_at < before)
+              .map((s) => ({ id: s.id, payload: s.payload }))
+          : all.map((s) => ({ id: s.id, payload: s.payload }));
+      }
+
+      if (targets.length === 0) {
+        return {
+          content: [
+            { type: "text", text: "対象セッションが見つかりませんでした。" },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(targets, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/delete_session.ts
+++ b/src/tools/delete_session.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolName } from "@/constants/index.js";
+import { deleteSessions } from "@/store/index.js";
+
+/** session_ids の配列で複数件削除する */
+export function registerDeleteSession(server: McpServer): void {
+  server.registerTool(
+    ToolName.DeleteSession,
+    {
+      description: "session_ids で指定したセッションを一括削除する。",
+      inputSchema: {
+        session_ids: z
+          .array(z.uuid())
+          .min(1)
+          .describe("削除対象のセッション ID の配列"),
+      },
+    },
+    async ({ session_ids }) => {
+      const result = await deleteSessions(session_ids);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${result.deleted} 件のセッションを削除しました。`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,11 +3,34 @@ import { registerPreviewSession } from "@/tools/preview_session.js";
 import { registerSaveSession } from "@/tools/save_session.js";
 import { registerListSessions } from "@/tools/list_sessions.js";
 import { registerLoadSession } from "@/tools/load_session.js";
+import { registerSearchSessions } from "@/tools/search_sessions.js";
+import { registerUpdateSession } from "@/tools/update_session.js";
+import { registerCompactSessions } from "@/tools/compact_sessions.js";
+import { registerDeleteSession } from "@/tools/delete_session.js";
 
-/** Phase 5 の基本ツール 4 本をサーバーに登録する */
+/** 全ツールをサーバーに登録する */
 export function registerTools(server: McpServer): void {
+  // preview_session: 保存前にセッション内容をプレビューする
   registerPreviewSession(server);
+
+  // save_session: セッションを Qdrant に保存する
   registerSaveSession(server);
+
+  // list_sessions: 最近のセッションを降順で一覧表示する
   registerListSessions(server);
+
+  // load_session: 番号または session_id でセッションをロードする
   registerLoadSession(server);
+
+  // search_sessions: 自然言語クエリでセマンティック検索する
+  registerSearchSessions(server);
+
+  // update_session: 指定フィールドのみ部分更新する
+  registerUpdateSession(server);
+
+  // compact_sessions: 対象セッションの生データを返す (要約は Claude が行う)
+  registerCompactSessions(server);
+
+  // delete_session: session_ids で指定したセッションを一括削除する
+  registerDeleteSession(server);
 }

--- a/src/tools/search_sessions.ts
+++ b/src/tools/search_sessions.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ToolName,
+  LIST_DEFAULT_LIMIT,
+  LIST_MAX_LIMIT,
+} from "@/constants/index.js";
+import { searchSessions } from "@/store/index.js";
+import { formatSessionLine } from "@/tools/format.js";
+
+/** 自然言語クエリでセマンティック検索し、スコア付き番号一覧で返す */
+export function registerSearchSessions(server: McpServer): void {
+  server.registerTool(
+    ToolName.SearchSessions,
+    {
+      description:
+        "自然言語クエリでセマンティック検索し、類似度スコア付きの番号一覧を返す。",
+      inputSchema: {
+        query: z.string().describe("自然言語の検索クエリ"),
+        limit: z
+          .number()
+          .optional()
+          .describe(
+            `取得件数。デフォルト ${LIST_DEFAULT_LIMIT}、最大 ${LIST_MAX_LIMIT}`,
+          ),
+        repo: z.string().optional().describe("repos[].repo での絞り込み"),
+        layer: z.string().optional().describe("layer での絞り込み"),
+      },
+    },
+    async ({ query, limit, repo, layer }) => {
+      const sessions = await searchSessions(query, limit, repo, layer);
+
+      if (sessions.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "該当するセッションが見つかりませんでした。",
+            },
+          ],
+        };
+      }
+
+      const lines = sessions.map((s, i) =>
+        formatSessionLine(i + 1, s.id, s.payload, s.score),
+      );
+
+      return { content: [{ type: "text", text: lines.join("\n\n") }] };
+    },
+  );
+}

--- a/src/tools/update_session.ts
+++ b/src/tools/update_session.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolName } from "@/constants/index.js";
+import { updateSession } from "@/store/index.js";
+
+/** 指定フィールドのみ部分更新する。ベクター再生成が必要なフィールドは自動的に再生成する */
+export function registerUpdateSession(server: McpServer): void {
+  server.registerTool(
+    ToolName.UpdateSession,
+    {
+      description:
+        "指定フィールドのみ部分更新する。title / summary / key_decisions を変更した場合はベクターを再生成する。updated_at は常に自動更新される。",
+      inputSchema: {
+        session_id: z.uuid().describe("更新対象のセッション ID"),
+        title: z.string().optional().describe("セッションの短いタイトル"),
+        summary: z
+          .string()
+          .optional()
+          .describe("セッション全体の要約 (500字程度)"),
+        status: z
+          .enum(["in_progress", "blocked", "completed", "abandoned"])
+          .optional()
+          .describe("作業の進行状態"),
+        key_decisions: z
+          .array(z.string())
+          .optional()
+          .describe("主要な意思決定の箇条書き"),
+        phase: z
+          .object({
+            current: z.number(),
+            total: z.number(),
+            completed_phases: z.array(z.string()),
+            next_action: z.string(),
+          })
+          .nullable()
+          .optional()
+          .describe("フェーズ進捗。null で削除"),
+        blocked_by: z
+          .array(
+            z.object({
+              type: z.enum(["issue", "pr", "session"]),
+              url: z.string(),
+              title: z.string(),
+              reason: z.string(),
+            }),
+          )
+          .optional()
+          .describe("ブロッカー・依存関係"),
+        code_references: z
+          .array(
+            z.object({
+              file: z.string(),
+              symbols: z.array(z.string()),
+              note: z.string(),
+            }),
+          )
+          .optional()
+          .describe("触ったファイル・関数・変数"),
+        external_references: z
+          .array(
+            z.object({
+              url: z.string(),
+              title: z.string(),
+              quote: z.string(),
+              note: z.string(),
+            }),
+          )
+          .optional()
+          .describe("参照したドキュメント URL"),
+        github_references: z
+          .array(
+            z.object({
+              type: z.enum(["issue", "pr", "discussion"]),
+              url: z.string(),
+              title: z.string(),
+              note: z.string(),
+            }),
+          )
+          .optional()
+          .describe("関連 Issue / PR / Discussion"),
+        artifacts: z
+          .array(
+            z.object({
+              type: z.enum(["branch", "migration", "tag", "file"]),
+              path: z.string(),
+              note: z.string(),
+            }),
+          )
+          .optional()
+          .describe("成果物"),
+        tags: z.array(z.string()).optional().describe("検索用タグ"),
+      },
+    },
+    async ({ session_id, ...updates }) => {
+      try {
+        const result = await updateSession(session_id, updates);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `session_id: ${result.session_id}\nupdated_at: ${result.updated_at}`,
+            },
+          ],
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.startsWith("SESSION_NOT_FOUND")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `session_id: ${session_id} が見つかりませんでした。`,
+              },
+            ],
+          };
+        }
+        throw err;
+      }
+    },
+  );
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 概要

Phase 6 として、検索・更新・集約・削除に関わる MCP ツール 4 本を実装した。

---

## 実装内容

### 何を、何のために実装したか

- `search_sessions` — 自然言語クエリでセマンティック検索し、スコア付き番号一覧を返す
- `update_session` — 指定フィールドのみ部分更新。`title` / `summary` / `key_decisions` 変更時はベクターを再生成。`updated_at` は常に自動更新
- `compact_sessions` — 対象セッションの生データを返す。Claude が要約し `save_session (source_ids 付き)` で保存することで元セッションが自動削除される
- `delete_session` — `session_ids: UUID[]` で複数件を一括削除
- `src/tools/index.ts` に 4 本を追加登録し、各呼び出しにコメントを付与
- `docs/README.md` / `docs/README.ja.md` の提供ツール一覧と使用例を更新

> [!NOTE]
>
> Zod v4 では `z.string().uuid()` が非推奨のため、`z.uuid()` を使用している。

### この実装がないとどうなるか

- セッションの検索・更新・集約・削除ができず、セッションメモリの保存と参照しか行えない

### 次の作業 (このPRでやっていないこと)

- Phase 7: エラーハンドリング (共通エラーレスポンス形式の実装)
- Phase 8: Claude Code 登録・動作確認

---

## 補足事項

ストア層 (`searchSessions` / `updateSession` / `deleteSessions`) は Phase 5 で実装済みのため、このPRでは MCP ツールのハンドラー実装のみ行っている。

---

## 関連 Issue

close #6

🤖 Generated with Claude Code