### PR TITLE
feat: 全ツール共通エラーハンドリングを実装 (Phase 7)

### DIFF
--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -1,4 +1,5 @@
 import { getExtractor } from "./pipeline.js";
+import { AppError, ErrorCode } from "@/errors/index.js";
 
 /**
  * テキストを 768 次元の埋め込みベクターに変換する。
@@ -9,7 +10,15 @@ import { getExtractor } from "./pipeline.js";
  * @returns 768 次元の float32 配列
  */
 export async function embed(text: string): Promise<number[]> {
-  const ext = await getExtractor();
-  const output = await ext(text, { pooling: "mean", normalize: true });
-  return Array.from(output.data as Float32Array);
+  try {
+    const ext = await getExtractor();
+    const output = await ext(text, { pooling: "mean", normalize: true });
+    return Array.from(output.data as Float32Array);
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw new AppError(
+      ErrorCode.EmbeddingError,
+      "埋め込みベクターの生成に失敗しました",
+    );
+  }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,86 @@
+/**
+ * 全ツール共通のエラーコード。
+ *
+ * - `QDRANT_CONNECTION_ERROR` — Qdrant が起動していない
+ * - `SESSION_NOT_FOUND` — 指定した session_id が存在しない
+ * - `EMBEDDING_ERROR` — 埋め込みベクターの生成に失敗
+ * - `VALIDATION_ERROR` — 入力パラメータが不正
+ */
+export const ErrorCode = {
+  QdrantConnectionError: "QDRANT_CONNECTION_ERROR",
+  SessionNotFound: "SESSION_NOT_FOUND",
+  EmbeddingError: "EMBEDDING_ERROR",
+  ValidationError: "VALIDATION_ERROR",
+} as const;
+
+/** {@link ErrorCode} のユニオン型 */
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * エラーコードに対応する推奨アクション。
+ *
+ * エラーレスポンスの `action` フィールドとして使用する。
+ */
+const ERROR_ACTIONS: Record<ErrorCode, string> = {
+  QDRANT_CONNECTION_ERROR:
+    "docker compose up -d を実行して Qdrant を起動してください",
+  SESSION_NOT_FOUND: "list_sessions で一覧を確認してください",
+  EMBEDDING_ERROR:
+    "make download-model を再実行してモデルを再ダウンロードしてください",
+  VALIDATION_ERROR: "error フィールドの詳細を確認してください",
+};
+
+/**
+ * アプリケーション固有のエラークラス。
+ *
+ * `code` に {@link ErrorCode} を持ち、`catchToErrorResponse` で
+ * 適切な MCP エラーレスポンスに変換される。
+ */
+export class AppError extends Error {
+  constructor(
+    public readonly code: ErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+/** エラーを MCP レスポンス形式に変換する */
+export function errorResponse(code: ErrorCode, message: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          { error: message, code, action: ERROR_ACTIONS[code] },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+/** catch ブロックで受け取った unknown をエラーレスポンスに変換する */
+export function catchToErrorResponse(err: unknown) {
+  if (err instanceof AppError) {
+    return errorResponse(err.code, err.message);
+  }
+
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (
+    msg.includes("ECONNREFUSED") ||
+    msg.includes("fetch failed") ||
+    msg.includes("Failed to fetch") ||
+    msg.includes("socket hang up")
+  ) {
+    return errorResponse(
+      ErrorCode.QdrantConnectionError,
+      "Qdrant に接続できませんでした",
+    );
+  }
+
+  throw err;
+}

--- a/src/store/sessions/mutation.ts
+++ b/src/store/sessions/mutation.ts
@@ -4,6 +4,7 @@ import type { SessionPayload } from "@/models/session.js";
 import { COLLECTION_NAME } from "@/constants/index.js";
 import { qdrant } from "@/store/client.js";
 import { loadSession } from "@/store/sessions/query.js";
+import { AppError, ErrorCode } from "@/errors/index.js";
 
 /** title + summary + key_decisions を結合して埋め込みの入力テキストを生成する */
 function buildEmbedInput(
@@ -79,7 +80,10 @@ export async function updateSession(
 ): Promise<{ session_id: string; updated_at: string }> {
   const current = await loadSession(sessionId);
   if (!current) {
-    throw new Error(`SESSION_NOT_FOUND: ${sessionId}`);
+    throw new AppError(
+      ErrorCode.SessionNotFound,
+      `session_id: ${sessionId} が見つかりませんでした`,
+    );
   }
 
   const now = new Date().toISOString();

--- a/src/tools/compact_sessions.ts
+++ b/src/tools/compact_sessions.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { listSessions, loadSession } from "@/store/index.js";
+import { catchToErrorResponse } from "@/errors/index.js";
 
 /**
  * 対象セッションの生データを返す。
@@ -33,38 +34,42 @@ export function registerCompactSessions(server: McpServer): void {
       },
     },
     async ({ session_ids, repo, before }) => {
-      let targets: Array<{ id: string; payload: unknown }>;
+      try {
+        let targets: Array<{ id: string; payload: unknown }>;
 
-      if (session_ids && session_ids.length > 0) {
-        const results = await Promise.all(session_ids.map(loadSession));
-        targets = results
-          .filter((r): r is NonNullable<typeof r> => r !== null)
-          .map((r) => ({ id: r.id, payload: r.payload }));
-      } else {
-        const all = await listSessions(50, repo);
-        targets = before
-          ? all
-              .filter((s) => s.payload.created_at < before)
-              .map((s) => ({ id: s.id, payload: s.payload }))
-          : all.map((s) => ({ id: s.id, payload: s.payload }));
-      }
+        if (session_ids && session_ids.length > 0) {
+          const results = await Promise.all(session_ids.map(loadSession));
+          targets = results
+            .filter((r): r is NonNullable<typeof r> => r !== null)
+            .map((r) => ({ id: r.id, payload: r.payload }));
+        } else {
+          const all = await listSessions(50, repo);
+          targets = before
+            ? all
+                .filter((s) => s.payload.created_at < before)
+                .map((s) => ({ id: s.id, payload: s.payload }))
+            : all.map((s) => ({ id: s.id, payload: s.payload }));
+        }
 
-      if (targets.length === 0) {
+        if (targets.length === 0) {
+          return {
+            content: [
+              { type: "text", text: "対象セッションが見つかりませんでした。" },
+            ],
+          };
+        }
+
         return {
           content: [
-            { type: "text", text: "対象セッションが見つかりませんでした。" },
+            {
+              type: "text",
+              text: JSON.stringify(targets, null, 2),
+            },
           ],
         };
+      } catch (err) {
+        return catchToErrorResponse(err);
       }
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(targets, null, 2),
-          },
-        ],
-      };
     },
   );
 }

--- a/src/tools/delete_session.ts
+++ b/src/tools/delete_session.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { deleteSessions } from "@/store/index.js";
+import { catchToErrorResponse } from "@/errors/index.js";
 
 /** session_ids の配列で複数件削除する */
 export function registerDeleteSession(server: McpServer): void {
@@ -17,15 +18,19 @@ export function registerDeleteSession(server: McpServer): void {
       },
     },
     async ({ session_ids }) => {
-      const result = await deleteSessions(session_ids);
-      return {
-        content: [
-          {
-            type: "text",
-            text: `${result.deleted} 件のセッションを削除しました。`,
-          },
-        ],
-      };
+      try {
+        const result = await deleteSessions(session_ids);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${result.deleted} 件のセッションを削除しました。`,
+            },
+          ],
+        };
+      } catch (err) {
+        return catchToErrorResponse(err);
+      }
     },
   );
 }

--- a/src/tools/list_sessions.ts
+++ b/src/tools/list_sessions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/constants/index.js";
 import { listSessions } from "@/store/index.js";
 import { formatSessionLine } from "@/tools/format.js";
+import { catchToErrorResponse } from "@/errors/index.js";
 
 /** 最近のセッションを番号付き一覧で返す */
 export function registerListSessions(server: McpServer): void {
@@ -27,21 +28,25 @@ export function registerListSessions(server: McpServer): void {
       },
     },
     async ({ limit, repo, layer }) => {
-      const sessions = await listSessions(limit, repo, layer);
+      try {
+        const sessions = await listSessions(limit, repo, layer);
 
-      if (sessions.length === 0) {
-        return {
-          content: [
-            { type: "text", text: "セッションが見つかりませんでした。" },
-          ],
-        };
+        if (sessions.length === 0) {
+          return {
+            content: [
+              { type: "text", text: "セッションが見つかりませんでした。" },
+            ],
+          };
+        }
+
+        const lines = sessions.map((s, i) =>
+          formatSessionLine(i + 1, s.id, s.payload),
+        );
+
+        return { content: [{ type: "text", text: lines.join("\n\n") }] };
+      } catch (err) {
+        return catchToErrorResponse(err);
       }
-
-      const lines = sessions.map((s, i) =>
-        formatSessionLine(i + 1, s.id, s.payload),
-      );
-
-      return { content: [{ type: "text", text: lines.join("\n\n") }] };
     },
   );
 }

--- a/src/tools/load_session.ts
+++ b/src/tools/load_session.ts
@@ -3,6 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName, LIST_MAX_LIMIT } from "@/constants/index.js";
 import { loadSession, listSessions } from "@/store/index.js";
 import { formatSessionDetail } from "@/tools/format.js";
+import {
+  ErrorCode,
+  errorResponse,
+  catchToErrorResponse,
+} from "@/errors/index.js";
 
 /**
  * 番号または session_id を指定してセッションを完全ロードする。
@@ -28,72 +33,59 @@ export function registerLoadSession(server: McpServer): void {
       },
     },
     async ({ number, session_id }) => {
-      if (number !== undefined) {
-        const sessions = await listSessions(LIST_MAX_LIMIT);
-        const target = sessions[number - 1];
-        if (!target) {
+      try {
+        if (number !== undefined) {
+          const sessions = await listSessions(LIST_MAX_LIMIT);
+          const target = sessions[number - 1];
+          if (!target) {
+            return errorResponse(
+              ErrorCode.SessionNotFound,
+              `番号 ${number} のセッションが見つかりませんでした`,
+            );
+          }
+          const byNumber = await loadSession(target.id);
+          if (!byNumber) {
+            return errorResponse(
+              ErrorCode.SessionNotFound,
+              `session_id: ${target.id} が見つかりませんでした`,
+            );
+          }
           return {
             content: [
               {
                 type: "text",
-                text: `番号 ${number} のセッションが見つかりませんでした。list_sessions で一覧を確認してください。`,
+                text: formatSessionDetail(byNumber.id, byNumber.payload),
               },
             ],
           };
         }
-        const byNumber = await loadSession(target.id);
-        if (!byNumber) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `session_id: ${target.id} が見つかりませんでした。`,
-              },
-            ],
-          };
+
+        if (!session_id) {
+          return errorResponse(
+            ErrorCode.ValidationError,
+            "number または session_id のいずれかを指定してください",
+          );
         }
+
+        const byId = await loadSession(session_id);
+        if (!byId) {
+          return errorResponse(
+            ErrorCode.SessionNotFound,
+            `session_id: ${session_id} が見つかりませんでした`,
+          );
+        }
+
         return {
           content: [
             {
               type: "text",
-              text: formatSessionDetail(byNumber.id, byNumber.payload),
+              text: formatSessionDetail(byId.id, byId.payload),
             },
           ],
         };
+      } catch (err) {
+        return catchToErrorResponse(err);
       }
-
-      if (!session_id) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "number または session_id のいずれかを指定してください。",
-            },
-          ],
-        };
-      }
-
-      // ここでは session_id が string に絞り込まれる
-      const byId = await loadSession(session_id);
-      if (!byId) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `session_id: ${session_id} が見つかりませんでした。`,
-            },
-          ],
-        };
-      }
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: formatSessionDetail(byId.id, byId.payload),
-          },
-        ],
-      };
     },
   );
 }

--- a/src/tools/save_session.ts
+++ b/src/tools/save_session.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { saveSession } from "@/store/index.js";
 import { SessionInputSchema, type SessionInput } from "@/tools/schemas.js";
+import { catchToErrorResponse } from "@/errors/index.js";
 
 /**
  * 確認済みセッションデータを Qdrant に保存する。
@@ -30,21 +31,25 @@ export function registerSaveSession(server: McpServer): void {
       source_ids,
       ...input
     }: SessionInput & { source_ids?: string[] }) => {
-      const result = await saveSession(
-        {
-          ...input,
-          compacted: source_ids !== undefined && source_ids.length > 0,
-        },
-        source_ids,
-      );
+      try {
+        const result = await saveSession(
+          {
+            ...input,
+            compacted: source_ids !== undefined && source_ids.length > 0,
+          },
+          source_ids,
+        );
 
-      const text = [
-        "セッションを保存しました。",
-        `session_id: ${result.session_id}`,
-        `created_at: ${result.created_at}`,
-      ].join("\n");
+        const text = [
+          "セッションを保存しました。",
+          `session_id: ${result.session_id}`,
+          `created_at: ${result.created_at}`,
+        ].join("\n");
 
-      return { content: [{ type: "text", text }] };
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        return catchToErrorResponse(err);
+      }
     },
   );
 }

--- a/src/tools/search_sessions.ts
+++ b/src/tools/search_sessions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/constants/index.js";
 import { searchSessions } from "@/store/index.js";
 import { formatSessionLine } from "@/tools/format.js";
+import { catchToErrorResponse } from "@/errors/index.js";
 
 /** 自然言語クエリでセマンティック検索し、スコア付き番号一覧で返す */
 export function registerSearchSessions(server: McpServer): void {
@@ -28,24 +29,28 @@ export function registerSearchSessions(server: McpServer): void {
       },
     },
     async ({ query, limit, repo, layer }) => {
-      const sessions = await searchSessions(query, limit, repo, layer);
+      try {
+        const sessions = await searchSessions(query, limit, repo, layer);
 
-      if (sessions.length === 0) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "該当するセッションが見つかりませんでした。",
-            },
-          ],
-        };
+        if (sessions.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "該当するセッションが見つかりませんでした。",
+              },
+            ],
+          };
+        }
+
+        const lines = sessions.map((s, i) =>
+          formatSessionLine(i + 1, s.id, s.payload, s.score),
+        );
+
+        return { content: [{ type: "text", text: lines.join("\n\n") }] };
+      } catch (err) {
+        return catchToErrorResponse(err);
       }
-
-      const lines = sessions.map((s, i) =>
-        formatSessionLine(i + 1, s.id, s.payload, s.score),
-      );
-
-      return { content: [{ type: "text", text: lines.join("\n\n") }] };
     },
   );
 }

--- a/src/tools/update_session.ts
+++ b/src/tools/update_session.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { updateSession } from "@/store/index.js";
+import { catchToErrorResponse } from "@/errors/index.js";
 
 /** 指定フィールドのみ部分更新する。ベクター再生成が必要なフィールドは自動的に再生成する */
 export function registerUpdateSession(server: McpServer): void {
@@ -103,18 +104,7 @@ export function registerUpdateSession(server: McpServer): void {
           ],
         };
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.startsWith("SESSION_NOT_FOUND")) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `session_id: ${session_id} が見つかりませんでした。`,
-              },
-            ],
-          };
-        }
-        throw err;
+        return catchToErrorResponse(err);
       }
     },
   );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 概要

Phase 7 として、全 MCP ツール共通のエラーレスポンス形式を実装した。

---

## 実装内容

### 何を、何のために実装したか

**`src/errors/index.ts` (新規)**

- `ErrorCode` — `QDRANT_CONNECTION_ERROR` / `SESSION_NOT_FOUND` / `EMBEDDING_ERROR` / `VALIDATION_ERROR` の 4 種を定義
- `AppError` — `ErrorCode` を持つアプリケーション固有のエラークラス
- `errorResponse()` — エラーコードとメッセージを MCP レスポンス形式の JSON に変換するヘルパー
- `catchToErrorResponse()` — `catch` ブロックで受け取った `unknown` を共通エラーレスポンスに変換。`AppError` はコードに応じて変換し、Qdrant 接続エラー (ECONNREFUSED 等) は `QDRANT_CONNECTION_ERROR` にマップする

**ストア層・埋め込み層**

- `src/embedder/index.ts` — 埋め込み失敗時に `AppError(EmbeddingError)` を throw
- `src/store/sessions/mutation.ts` — `SESSION_NOT_FOUND` を `AppError` に変更

**全 7 ツール**

- ハンドラー全体を `try-catch` でラップし、`catchToErrorResponse()` を適用
- `load_session` のインライン "not found" 返却を `errorResponse()` に統一

**エラーレスポンス形式:**

```json
{
  "error": "Qdrant に接続できませんでした",
  "code": "QDRANT_CONNECTION_ERROR",
  "action": "docker compose up -d を実行して Qdrant を起動してください"
}
```

### この実装がないとどうなるか

- Qdrant が停止している状態でツールを呼び出すと、スタックトレースがそのまま返り Claude が適切に対処できない
- エラーの種類によって返却フォーマットが統一されておらず、`action` (復旧手順) が伝わらない

### 次の作業 (このPRでやっていないこと)

- Phase 8: Claude Code 登録・動作確認

---

## 補足事項

> [!NOTE]
>
> `catchToErrorResponse()` は予期しないエラー (上記 4 種に該当しないもの) は `throw` で再スローする。
> MCP サーバーレベルでのエラーとして扱われ、Claude Code に伝播する。

---

## 関連 Issue

close #7

🤖 Generated with Claude Code