### PR TITLE
refactor: パフォーマンス改善とコードリファクタリング

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -46,8 +46,11 @@ export class AppError extends Error {
   }
 }
 
+/** MCP ツールハンドラーの共通レスポンス型 */
+export type ToolResponse = { content: Array<{ type: "text"; text: string }> };
+
 /** エラーを MCP レスポンス形式に変換する */
-export function errorResponse(code: ErrorCode, message: string) {
+export function errorResponse(code: ErrorCode, message: string): ToolResponse {
   return {
     content: [
       {
@@ -63,7 +66,7 @@ export function errorResponse(code: ErrorCode, message: string) {
 }
 
 /** catch ブロックで受け取った unknown をエラーレスポンスに変換する */
-export function catchToErrorResponse(err: unknown) {
+export function catchToErrorResponse(err: unknown): ToolResponse {
   if (err instanceof AppError) {
     return errorResponse(err.code, err.message);
   }
@@ -83,4 +86,19 @@ export function catchToErrorResponse(err: unknown) {
   }
 
   throw err;
+}
+
+/**
+ * ツールハンドラーを try-catch でラップし、エラー時に共通レスポンスを返す。
+ *
+ * 各ツールで繰り返される try-catch ボイラープレートを削減するためのヘルパー。
+ */
+export async function withErrorHandling(
+  fn: () => Promise<ToolResponse>,
+): Promise<ToolResponse> {
+  try {
+    return await fn();
+  } catch (err) {
+    return catchToErrorResponse(err);
+  }
 }

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -1,3 +1,23 @@
+import type {
+  Repo,
+  Phase,
+  BlockedBy,
+  CodeReference,
+  ExternalReference,
+  GitHubReference,
+  Artifact,
+} from "@/schemas/index.js";
+
+export type {
+  Repo,
+  Phase,
+  BlockedBy,
+  CodeReference,
+  ExternalReference,
+  GitHubReference,
+  Artifact,
+};
+
 export const Status = {
   InProgress: "in_progress",
   Blocked: "blocked",
@@ -17,52 +37,6 @@ export const Layer = {
 } as const;
 
 export type Layer = (typeof Layer)[keyof typeof Layer];
-
-export type Repo = {
-  owner: string;
-  repo: string;
-  role: "primary" | "related";
-};
-
-export type Phase = {
-  current: number;
-  total: number;
-  completed_phases: string[];
-  next_action: string;
-};
-
-export type BlockedBy = {
-  type: "issue" | "pr" | "session";
-  url: string;
-  title: string;
-  reason: string;
-};
-
-export type CodeReference = {
-  file: string;
-  symbols: string[];
-  note: string;
-};
-
-export type ExternalReference = {
-  url: string;
-  title: string;
-  quote: string;
-  note: string;
-};
-
-export type GitHubReference = {
-  type: "issue" | "pr" | "discussion";
-  url: string;
-  title: string;
-  note: string;
-};
-
-export type Artifact = {
-  type: "branch" | "migration" | "tag" | "file";
-  path: string;
-  note: string;
-};
 
 export type SessionPayload = {
   title: string;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const RepoSchema = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  role: z.enum(["primary", "related"]),
+});
+
+export const PhaseSchema = z.object({
+  current: z.number(),
+  total: z.number(),
+  completed_phases: z.array(z.string()),
+  next_action: z.string(),
+});
+
+export const BlockedBySchema = z.object({
+  type: z.enum(["issue", "pr", "session"]),
+  url: z.string(),
+  title: z.string(),
+  reason: z.string(),
+});
+
+export const CodeReferenceSchema = z.object({
+  file: z.string(),
+  symbols: z.array(z.string()),
+  note: z.string(),
+});
+
+export const ExternalReferenceSchema = z.object({
+  url: z.string(),
+  title: z.string(),
+  quote: z.string(),
+  note: z.string(),
+});
+
+export const GitHubReferenceSchema = z.object({
+  type: z.enum(["issue", "pr", "discussion"]),
+  url: z.string(),
+  title: z.string(),
+  note: z.string(),
+});
+
+export const ArtifactSchema = z.object({
+  type: z.enum(["branch", "migration", "tag", "file"]),
+  path: z.string(),
+  note: z.string(),
+});
+
+export type Repo = z.infer<typeof RepoSchema>;
+export type Phase = z.infer<typeof PhaseSchema>;
+export type BlockedBy = z.infer<typeof BlockedBySchema>;
+export type CodeReference = z.infer<typeof CodeReferenceSchema>;
+export type ExternalReference = z.infer<typeof ExternalReferenceSchema>;
+export type GitHubReference = z.infer<typeof GitHubReferenceSchema>;
+export type Artifact = z.infer<typeof ArtifactSchema>;

--- a/src/store/sessions/query.ts
+++ b/src/store/sessions/query.ts
@@ -7,6 +7,11 @@ import {
 import { embed } from "@/embedder/index.js";
 import { qdrant } from "@/store/client.js";
 
+/** Qdrant から返される payload を SessionPayload にキャストする */
+function asSessionPayload(raw: unknown): SessionPayload {
+  return raw as SessionPayload;
+}
+
 /** repo / layer フィルターを Qdrant Filter 形式に変換する */
 function buildFilter(repo?: string, layer?: string) {
   const must: unknown[] = [];
@@ -43,7 +48,7 @@ export async function listSessions(
 
   return result.points.map((p) => ({
     id: String(p.id),
-    payload: p.payload as unknown as SessionPayload,
+    payload: asSessionPayload(p.payload),
   }));
 }
 
@@ -68,7 +73,7 @@ export async function searchSessions(
   return result.map((p) => ({
     id: String(p.id),
     score: p.score,
-    payload: p.payload as unknown as SessionPayload,
+    payload: asSessionPayload(p.payload),
   }));
 }
 
@@ -86,6 +91,6 @@ export async function loadSession(
   const point = result[0];
   return {
     id: String(point.id),
-    payload: point.payload as unknown as SessionPayload,
+    payload: asSessionPayload(point.payload),
   };
 }

--- a/src/tools/compact_sessions.ts
+++ b/src/tools/compact_sessions.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
+import type { SessionPayload } from "@/models/session.js";
 import { listSessions, loadSession } from "@/store/index.js";
-import { catchToErrorResponse } from "@/errors/index.js";
+import { withErrorHandling } from "@/errors/index.js";
 
 /**
  * 対象セッションの生データを返す。
@@ -33,9 +34,9 @@ export function registerCompactSessions(server: McpServer): void {
           ),
       },
     },
-    async ({ session_ids, repo, before }) => {
-      try {
-        let targets: Array<{ id: string; payload: unknown }>;
+    ({ session_ids, repo, before }) =>
+      withErrorHandling(async () => {
+        let targets: Array<{ id: string; payload: SessionPayload }>;
 
         if (session_ids && session_ids.length > 0) {
           const results = await Promise.all(session_ids.map(loadSession));
@@ -67,9 +68,6 @@ export function registerCompactSessions(server: McpServer): void {
             },
           ],
         };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }

--- a/src/tools/delete_session.ts
+++ b/src/tools/delete_session.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { deleteSessions } from "@/store/index.js";
-import { catchToErrorResponse } from "@/errors/index.js";
+import { withErrorHandling } from "@/errors/index.js";
 
 /** session_ids の配列で複数件削除する */
 export function registerDeleteSession(server: McpServer): void {
@@ -17,8 +17,8 @@ export function registerDeleteSession(server: McpServer): void {
           .describe("削除対象のセッション ID の配列"),
       },
     },
-    async ({ session_ids }) => {
-      try {
+    ({ session_ids }) =>
+      withErrorHandling(async () => {
         const result = await deleteSessions(session_ids);
         return {
           content: [
@@ -28,9 +28,6 @@ export function registerDeleteSession(server: McpServer): void {
             },
           ],
         };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }

--- a/src/tools/list_sessions.ts
+++ b/src/tools/list_sessions.ts
@@ -7,7 +7,7 @@ import {
 } from "@/constants/index.js";
 import { listSessions } from "@/store/index.js";
 import { formatSessionLine } from "@/tools/format.js";
-import { catchToErrorResponse } from "@/errors/index.js";
+import { withErrorHandling } from "@/errors/index.js";
 
 /** 最近のセッションを番号付き一覧で返す */
 export function registerListSessions(server: McpServer): void {
@@ -27,8 +27,8 @@ export function registerListSessions(server: McpServer): void {
         layer: z.string().optional().describe("layer での絞り込み"),
       },
     },
-    async ({ limit, repo, layer }) => {
-      try {
+    ({ limit, repo, layer }) =>
+      withErrorHandling(async () => {
         const sessions = await listSessions(limit, repo, layer);
 
         if (sessions.length === 0) {
@@ -44,9 +44,6 @@ export function registerListSessions(server: McpServer): void {
         );
 
         return { content: [{ type: "text", text: lines.join("\n\n") }] };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }

--- a/src/tools/load_session.ts
+++ b/src/tools/load_session.ts
@@ -3,11 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName, LIST_MAX_LIMIT } from "@/constants/index.js";
 import { loadSession, listSessions } from "@/store/index.js";
 import { formatSessionDetail } from "@/tools/format.js";
-import {
-  ErrorCode,
-  errorResponse,
-  catchToErrorResponse,
-} from "@/errors/index.js";
+import { ErrorCode, errorResponse, withErrorHandling } from "@/errors/index.js";
 
 /**
  * 番号または session_id を指定してセッションを完全ロードする。
@@ -32,8 +28,8 @@ export function registerLoadSession(server: McpServer): void {
           .describe("セッション ID を直接指定する場合"),
       },
     },
-    async ({ number, session_id }) => {
-      try {
+    ({ number, session_id }) =>
+      withErrorHandling(async () => {
         if (number !== undefined) {
           const sessions = await listSessions(LIST_MAX_LIMIT);
           const target = sessions[number - 1];
@@ -43,18 +39,12 @@ export function registerLoadSession(server: McpServer): void {
               `番号 ${number} のセッションが見つかりませんでした`,
             );
           }
-          const byNumber = await loadSession(target.id);
-          if (!byNumber) {
-            return errorResponse(
-              ErrorCode.SessionNotFound,
-              `session_id: ${target.id} が見つかりませんでした`,
-            );
-          }
+          // listSessions は with_payload: true で取得しているため再フェッチ不要
           return {
             content: [
               {
                 type: "text",
-                text: formatSessionDetail(byNumber.id, byNumber.payload),
+                text: formatSessionDetail(target.id, target.payload),
               },
             ],
           };
@@ -83,9 +73,6 @@ export function registerLoadSession(server: McpServer): void {
             },
           ],
         };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }

--- a/src/tools/save_session.ts
+++ b/src/tools/save_session.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { saveSession } from "@/store/index.js";
 import { SessionInputSchema, type SessionInput } from "@/tools/schemas.js";
-import { catchToErrorResponse } from "@/errors/index.js";
+import { withErrorHandling } from "@/errors/index.js";
 
 /**
  * 確認済みセッションデータを Qdrant に保存する。
@@ -27,11 +27,8 @@ export function registerSaveSession(server: McpServer): void {
           ),
       },
     },
-    async ({
-      source_ids,
-      ...input
-    }: SessionInput & { source_ids?: string[] }) => {
-      try {
+    ({ source_ids, ...input }: SessionInput & { source_ids?: string[] }) =>
+      withErrorHandling(async () => {
         const result = await saveSession(
           {
             ...input,
@@ -47,9 +44,6 @@ export function registerSaveSession(server: McpServer): void {
         ].join("\n");
 
         return { content: [{ type: "text", text }] };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1,50 +1,13 @@
 import { z } from "zod";
-
-const RepoSchema = z.object({
-  owner: z.string(),
-  repo: z.string(),
-  role: z.enum(["primary", "related"]),
-});
-
-const PhaseSchema = z.object({
-  current: z.number(),
-  total: z.number(),
-  completed_phases: z.array(z.string()),
-  next_action: z.string(),
-});
-
-const BlockedBySchema = z.object({
-  type: z.enum(["issue", "pr", "session"]),
-  url: z.string(),
-  title: z.string(),
-  reason: z.string(),
-});
-
-const CodeReferenceSchema = z.object({
-  file: z.string(),
-  symbols: z.array(z.string()),
-  note: z.string(),
-});
-
-const ExternalReferenceSchema = z.object({
-  url: z.string(),
-  title: z.string(),
-  quote: z.string(),
-  note: z.string(),
-});
-
-const GitHubReferenceSchema = z.object({
-  type: z.enum(["issue", "pr", "discussion"]),
-  url: z.string(),
-  title: z.string(),
-  note: z.string(),
-});
-
-const ArtifactSchema = z.object({
-  type: z.enum(["branch", "migration", "tag", "file"]),
-  path: z.string(),
-  note: z.string(),
-});
+import {
+  RepoSchema,
+  PhaseSchema,
+  BlockedBySchema,
+  CodeReferenceSchema,
+  ExternalReferenceSchema,
+  GitHubReferenceSchema,
+  ArtifactSchema,
+} from "@/schemas/index.js";
 
 /** save_session / preview_session の共通入力スキーマ */
 export const SessionInputSchema = z.object({

--- a/src/tools/search_sessions.ts
+++ b/src/tools/search_sessions.ts
@@ -7,7 +7,7 @@ import {
 } from "@/constants/index.js";
 import { searchSessions } from "@/store/index.js";
 import { formatSessionLine } from "@/tools/format.js";
-import { catchToErrorResponse } from "@/errors/index.js";
+import { withErrorHandling } from "@/errors/index.js";
 
 /** 自然言語クエリでセマンティック検索し、スコア付き番号一覧で返す */
 export function registerSearchSessions(server: McpServer): void {
@@ -28,8 +28,8 @@ export function registerSearchSessions(server: McpServer): void {
         layer: z.string().optional().describe("layer での絞り込み"),
       },
     },
-    async ({ query, limit, repo, layer }) => {
-      try {
+    ({ query, limit, repo, layer }) =>
+      withErrorHandling(async () => {
         const sessions = await searchSessions(query, limit, repo, layer);
 
         if (sessions.length === 0) {
@@ -48,9 +48,6 @@ export function registerSearchSessions(server: McpServer): void {
         );
 
         return { content: [{ type: "text", text: lines.join("\n\n") }] };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }

--- a/src/tools/update_session.ts
+++ b/src/tools/update_session.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolName } from "@/constants/index.js";
 import { updateSession } from "@/store/index.js";
-import { catchToErrorResponse } from "@/errors/index.js";
+import { withErrorHandling } from "@/errors/index.js";
 
 /** 指定フィールドのみ部分更新する。ベクター再生成が必要なフィールドは自動的に再生成する */
 export function registerUpdateSession(server: McpServer): void {
@@ -92,8 +92,8 @@ export function registerUpdateSession(server: McpServer): void {
         tags: z.array(z.string()).optional().describe("検索用タグ"),
       },
     },
-    async ({ session_id, ...updates }) => {
-      try {
+    ({ session_id, ...updates }) =>
+      withErrorHandling(async () => {
         const result = await updateSession(session_id, updates);
         return {
           content: [
@@ -103,9 +103,6 @@ export function registerUpdateSession(server: McpServer): void {
             },
           ],
         };
-      } catch (err) {
-        return catchToErrorResponse(err);
-      }
-    },
+      }),
   );
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 概要

コード全体の調査を踏まえ、パフォーマンス改善とリファクタリングを実施した。
機能への影響はなく、ビルドも通過している。

---

## 実装内容

### 何を、何のために実装したか

**パフォーマンス改善**

- `load_session.ts` — `number` 指定時に `listSessions` の結果ペイロードをそのまま返すよう変更。
  従来は `listSessions` で全セッションを取得した後、再度 `loadSession(target.id)` で Qdrant にアクセスしていた。
  `listSessions` は `with_payload: true` で取得しているため再フェッチは不要で、Qdrant 呼び出しを1回削減できる

- `query.ts` — `as unknown as SessionPayload` キャストが3箇所に散在していた。
  `asSessionPayload()` ヘルパーに集約し、変更箇所を1か所に限定した

**リファクタリング**

- `errors/index.ts` — `ToolResponse` 型と `withErrorHandling()` ラッパーを追加。
  各ツールで繰り返されていた `try { ... } catch(err) { return catchToErrorResponse(err) }` パターンを `withErrorHandling(async () => { ... })` に統一し、約 30 行のボイラープレートを削減

- 全 7 ツール — `catchToErrorResponse` の直接 import を廃止し、`withErrorHandling` に一本化

- `compact_sessions.ts` — `payload: unknown` を `SessionPayload` に修正し型安全性を向上

- `src/schemas/index.ts` (新規) — `Repo`・`Phase`・`BlockedBy` など 7 つのサブ型を Zod スキーマとして定義し、`z.infer<>` で型を導出してエクスポート。唯一の真実のソースに集約

- `src/tools/schemas.ts` — サブスキーマのローカル定義を削除し `src/schemas/` から import

- `src/models/session.ts` — `Repo`・`Phase` など 7 型の手書き定義を削除し `src/schemas/` から import して re-export。`Status`・`Layer` の runtime const は維持

### この実装がないとどうなるか

- `number` 指定の `load_session` 呼び出し毎に Qdrant へ余分なリクエストが発生し続ける
- エラーハンドリングの追加・変更時に全ツールを個別修正する必要がある
- サブ型にフィールドを追加した場合、`schemas.ts` と `models/session.ts` の両方を修正しなければならない

### 次の作業 (このPRでやっていないこと)

- Phase 8: Claude Code 登録・動作確認

---

## 補足事項

> [!NOTE]
>
> `withErrorHandling` は `catchToErrorResponse` を内包しているため、
> 既存の `AppError` / Qdrant 接続エラーの検出ロジックはそのまま動作する。
> 予期しないエラーは引き続き `throw` で再スローされる。

> [!NOTE]
>
> `Status`・`Layer` は PascalCase キーを持つ runtime const (`Status.InProgress` など) のため
> Zod の `z.enum().enum` とキー名が異なり、`schemas/` への移行対象から除外した。

---

## 関連 Issue

<!-- close #n -->

🤖 Generated with Claude Code