### PR TITLE
feat: list_sessions を updated_at 降順に変更

### DIFF
--- a/src/store/client.ts
+++ b/src/store/client.ts
@@ -11,10 +11,14 @@ export async function initCollection(): Promise<void> {
     await qdrant.createCollection(COLLECTION_NAME, {
       vectors: { size: VECTOR_SIZE, distance: "Cosine" },
     });
-    // order_by: created_at で降順ソートするために datetime インデックスを作成する
-    await qdrant.createPayloadIndex(COLLECTION_NAME, {
-      field_name: "created_at",
-      field_schema: "datetime",
-    });
   }
+  // order_by で降順ソートするために datetime インデックスを作成する
+  await qdrant.createPayloadIndex(COLLECTION_NAME, {
+    field_name: "created_at",
+    field_schema: "datetime",
+  });
+  await qdrant.createPayloadIndex(COLLECTION_NAME, {
+    field_name: "updated_at",
+    field_schema: "datetime",
+  });
 }

--- a/src/store/sessions/query.ts
+++ b/src/store/sessions/query.ts
@@ -29,7 +29,7 @@ function buildFilter(repo?: string, layer?: string) {
   return must.length > 0 ? { must } : undefined;
 }
 
-/** 最近のセッションを created_at 降順で返す */
+/** 最近のセッションを updated_at 降順で返す */
 export async function listSessions(
   limit: number = LIST_DEFAULT_LIMIT,
   repo?: string,
@@ -43,7 +43,7 @@ export async function listSessions(
     limit: clampedLimit,
     with_payload: true,
     with_vector: false,
-    order_by: { key: "created_at", direction: "desc" },
+    order_by: { key: "updated_at", direction: "desc" },
   });
 
   return result.points.map((p) => ({

--- a/src/tools/list_sessions.ts
+++ b/src/tools/list_sessions.ts
@@ -15,7 +15,7 @@ export function registerListSessions(server: McpServer): void {
     ToolName.ListSessions,
     {
       description:
-        "最近のセッションを created_at 降順の番号付き一覧で返す。load_session の番号指定に使う。",
+        "最近のセッションを updated_at 降順の番号付き一覧で返す。load_session の番号指定に使う。",
       inputSchema: {
         limit: z
           .number()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 概要

`list_sessions` のソート順を `created_at` 降順から `updated_at` 降順に変更する。

---

## 実装内容

### 何を、何のために実装したか

- `src/store/sessions/query.ts` の `order_by` キーを `created_at` から `updated_at` に変更
- `src/store/client.ts` に `updated_at` の datetime インデックスを追加
- `src/tools/list_sessions.ts` のツール description を更新

最近更新されたセッションを上位に表示することで、実際に直近まで作業していたコンテキストを優先して取得できるようにする。

> [!IMPORTANT]
> `initCollection()` のインデックス作成処理をコレクション作成の `catch` ブロック外に移動した。
> これにより既存コレクションに対しても起動時に `updated_at` インデックスが付与されるようになる。

### この実装がないとどうなるか

`created_at` 順のままでは、内容を更新したセッションが一覧の下位に埋もれ、直近の作業コンテキストを見つけにくくなる。

### 次の作業 (このPRでやっていないこと)

特になし。

---

## 補足事項

Qdrant の `createPayloadIndex` はべき等であるため、起動のたびに同じインデックス作成を呼び出しても問題ない。

---

## 関連 Issue

<!-- close #n -->

🤖 Generated with Claude Code