### PR TITLE
feat: list_sessions / search_sessions の上限値を 50 件に変更

### DIFF
--- a/src/constants/query.ts
+++ b/src/constants/query.ts
@@ -2,4 +2,4 @@
 export const LIST_DEFAULT_LIMIT = 5;
 
 /** list_sessions / search_sessions の最大取得件数 */
-export const LIST_MAX_LIMIT = 10;
+export const LIST_MAX_LIMIT = 50;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 概要

`list_sessions` / `search_sessions` の最大取得件数を 10 件から 50 件に拡大する。

---

## 実装内容

### 何を、何のために実装したか

- `src/constants/query.ts` の `LIST_MAX_LIMIT` を `10` → `50` に変更

ツールの description は定数参照のため、追加修正なしで自動的に反映される。

### この実装がないとどうなるか

上限 10 件では、セッション数が増えた場合に一覧・検索で取得できる候補が少なく、目的のセッションを見つけにくくなる。

### 次の作業 (このPRでやっていないこと)

特になし。

---

## 補足事項

`LIST_DEFAULT_LIMIT` (デフォルト 5 件) は変更なし。

---

## 関連 Issue

<!-- close #n -->

🤖 Generated with Claude Code